### PR TITLE
Fixes projects view rendering

### DIFF
--- a/app/views/projects/index.jade
+++ b/app/views/projects/index.jade
@@ -17,7 +17,7 @@ block main
   .row#projects
     .grid-sm-14.grid-lg-12.offset-lg-1
       each project, index in projects
-        if index < numberOfProjects - 2
+        if index < numberOfProjects - 1
           article.m-project-card(style="background-image: url(/assets/images/projects/#{project.image})")
             .veil
             .m-project-content


### PR DESCRIPTION
A fix for @Jamie-Gibson :wave: 

Previously one project in the top 5 would always be hidden, because the group before and after the blog post were calculating which projects to show incorrectly. I don't know how this fits in with the design, i.e. do we want this many projects to be showing as large images, but this ensures that all projects are at least visible.
